### PR TITLE
changing a method to convert arrays to float32

### DIFF
--- a/kid.py
+++ b/kid.py
@@ -67,7 +67,7 @@ def rho_kid2dry(arr):
   return arr #TODO!
 
 def save_dg(arr, it, name, units):
-  arr = arr.astype(np.float32, copy=False)
+  arr.dtype ="float32"
   arr_ptr = ffi.cast("float*", arr.__array_interface__['data'][0])
   lib.__diagnostics_MOD_save_dg_2d_sp_c(
     arr_ptr, arr.shape[0], arr.shape[1], 


### PR DESCRIPTION
arr.astype() does not take  keyword arguments for numpy 1.6 
